### PR TITLE
changed generateTypes and  helpers/indexTemplate.js

### DIFF
--- a/packages/icon-store/scripts/generateTypes.js
+++ b/packages/icon-store/scripts/generateTypes.js
@@ -6,41 +6,39 @@
  */
 
 
-const { getDirContent, writeContentToFile } = require('./helpers/utils');
+ const { getDirContent, writeContentToFile } = require('./helpers/utils');
 
-const chalk = require('chalk');
-const { copyFileSync } = require('fs');
+ const chalk = require('chalk');
+ 
 
-
-function generateTypesForIconComponent() {
-    const componentFolderPaths = ['mi', 'custom'];
-
-    componentFolderPaths.forEach(componentFolderPath => {
-        console.log(chalk.green('Generating types for: ') + chalk.yellow(componentFolderPath));
-
-        const components = getDirContent(componentFolderPath);
-
-        components.forEach(component => {
-            if (component.includes('index.js')) {
-                copyFileSync(`${componentFolderPath}/index.js`, `${componentFolderPath}/index.d.ts`);
-                return;
-            }
-            if (component.endsWith('.js')) {
-                const componentName = component.slice(0, -3);
-
-                const content = `import { ReactIconComponentType } from '../types';
-
-declare const ${componentName}: ReactIconComponentType;
-export default ${componentName};
-            `
-
-                const filePath = `${componentFolderPath}/${componentName}.d.ts`;
-                writeContentToFile(filePath, content);
-            }
-        });
-
-        console.log(chalk.gray('Finished.\n\n'));
-    });
-}
-
-generateTypesForIconComponent();
+ function generateTypesForIconComponent() {
+     const componentFolderPaths = ['mi', 'custom'];
+ 
+     componentFolderPaths.forEach(componentFolderPath => {
+         console.log(chalk.green('Generating single index.d.ts: ') + chalk.yellow(componentFolderPath));
+ 
+         const components = getDirContent(componentFolderPath);
+         
+         const allComponentTypeLines = [`import {ReactIconComponentType} from "../types"`];
+         
+         const declarationPath = `${componentFolderPath}/index.d.ts`;
+ 
+         components.forEach(component => {
+ 
+             if(component.includes('.js')){
+                 
+                 const componentName = component.slice(0 , -3);
+                 const contentForComponent = `export var ${componentName}: ReactIconComponentType;`
+                 
+                 allComponentTypeLines.push(contentForComponent);
+             }
+             
+         });
+ 
+         writeContentToFile(declarationPath , allComponentTypeLines.join('\n'));
+ 
+         console.log(chalk.gray('Finished.\n\n'));
+     });
+ }
+ 
+ generateTypesForIconComponent();

--- a/packages/icon-store/scripts/generateTypes.js
+++ b/packages/icon-store/scripts/generateTypes.js
@@ -19,7 +19,7 @@
  
          const components = getDirContent(componentFolderPath);
          
-         const allComponentTypeLines = [`import {ReactIconComponentType} from "../types"`];
+         const allComponentTypeLines = [`import { ReactIconComponentType } from "../types"`];
          
          const declarationPath = `${componentFolderPath}/index.d.ts`;
  

--- a/packages/icon-store/scripts/generateTypes.js
+++ b/packages/icon-store/scripts/generateTypes.js
@@ -15,7 +15,7 @@
      const componentFolderPaths = ['mi', 'custom'];
  
      componentFolderPaths.forEach(componentFolderPath => {
-         console.log(chalk.green('Generating single index.d.ts: ') + chalk.yellow(componentFolderPath));
+         console.log(chalk.green('Generating types for: ') + chalk.yellow(componentFolderPath));
  
          const components = getDirContent(componentFolderPath);
          
@@ -31,6 +31,15 @@
                  const contentForComponent = `export var ${componentName}: ReactIconComponentType;`
                  
                  allComponentTypeLines.push(contentForComponent);
+
+                const content = `import { ReactIconComponentType } from '../types';
+
+declare const ${componentName}: ReactIconComponentType;
+export default ${componentName};
+                `
+
+                const componentDeclarationFilePath = `${componentFolderPath}/${componentName}.d.ts`;
+                writeContentToFile(componentDeclarationFilePath, content);
              }
              
          });

--- a/packages/icon-store/scripts/generateTypes.js
+++ b/packages/icon-store/scripts/generateTypes.js
@@ -25,8 +25,9 @@
  
          components.forEach(component => {
  
-             if(component.includes('.js')){
+             if(component.includes('.js') && component !== 'index.js'){
                  
+                 console.log(component);
                  const componentName = component.slice(0 , -3);
                  const contentForComponent = `export var ${componentName}: ReactIconComponentType;`
                  

--- a/packages/icon-store/scripts/helpers/indexTemplate.js
+++ b/packages/icon-store/scripts/helpers/indexTemplate.js
@@ -9,7 +9,7 @@ function defaultIndexTemplate(filePaths) {
     const exportEntries = uniqueFilePaths.map((filePath) => {
         const basename = path.basename(filePath, path.extname(filePath))
         const exportName = /^\d/.test(basename) ? `Material${basename}` : basename
-        return `export { default as ${exportName} } from './${basename}'`
+        return `exports.${exportName} = require('./${exportName}').default;`
     })
     return exportEntries.join('\n')
 }


### PR DESCRIPTION
## What does this PR do?
Changes the generateTypes and  indexTemplate for icon store , so that the output index.js file for both type of icon folders mi and custom are of the type es5. Next js does not compile node modules and hence in the earlier version the index.js fiels were getting directly sent to the browser leading to errors.

