### PR TITLE
Feat(Accordion): Accordion overflow visible on reveal

### DIFF
--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/ui-toolkit",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A lightning nature UI",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ui-toolkit/src/components/atoms/Accordion/Accordion.tsx
+++ b/packages/ui-toolkit/src/components/atoms/Accordion/Accordion.tsx
@@ -35,6 +35,7 @@ const MutableAccordion = (props: Props) => {
   } = props;
 
   const [ isOpen, toggleAccordion ] = useState(onMountOpen);
+  const [ isRevealComplete, setIsRevealComplete ] = useState(false);
 
   const childRef = useRef<HTMLDivElement>(null);
   const isFirstRender = useRef(true);
@@ -49,6 +50,10 @@ const MutableAccordion = (props: Props) => {
     if (onToggleCallback) {
       onToggleCallback(isOpen);
     }
+
+    if (!isOpen && isRevealComplete) {
+      setIsRevealComplete(false);
+    }
   }, [ isOpen ]);
 
 
@@ -57,7 +62,14 @@ const MutableAccordion = (props: Props) => {
   }, []);
 
 
-  const childClass = isOpen ? 'ac11Show' : 'ac11Hidden';
+  const onRevealComplete = () => {
+    if (isOpen) {
+      setIsRevealComplete(true);
+    }
+  };
+
+
+  const childClass = isOpen ? isRevealComplete ? 'ac11RevealComplete ac11Show' : 'ac11Show' : 'ac11Hidden';
 
   let childStyle = {};
 
@@ -106,6 +118,7 @@ const MutableAccordion = (props: Props) => {
         : <div className={childClass}
           style={childStyle}
           ref={childRef}
+          onTransitionEnd={onRevealComplete}
         >
           {children}
         </div>

--- a/packages/ui-toolkit/src/components/atoms/Accordion/Accordion.tsx
+++ b/packages/ui-toolkit/src/components/atoms/Accordion/Accordion.tsx
@@ -69,7 +69,20 @@ const MutableAccordion = (props: Props) => {
   };
 
 
-  const childClass = isOpen ? isRevealComplete ? 'ac11RevealComplete ac11Show' : 'ac11Show' : 'ac11Hidden';
+  const getChildClass = () => {
+
+    if (isOpen) {
+      if (isRevealComplete) {
+        return 'ac11RevealComplete ac11Show';
+      }
+
+      return 'ac11Show';
+    }
+
+    return 'ac11Hidden';
+  };
+
+  const childClass = getChildClass();
 
   let childStyle = {};
 

--- a/packages/ui-toolkit/src/components/atoms/Accordion/accordion.css
+++ b/packages/ui-toolkit/src/components/atoms/Accordion/accordion.css
@@ -18,6 +18,10 @@
   /* transition: max-height 0.5s cubic-bezier(0, 1, 0, 1); */
 }
 
+.ac11RevealComplete {
+  overflow: visible;
+}
+
 .ac11collapsibleOpen {
   transform: rotate(180deg);
 }


### PR DESCRIPTION
## What does this PR do?

Added an extra state isRevealComplete to trigger on transitionEnd and
set the overflow state of the accordion to visible so that overflowing
content is not clipped. When the accordion is closed, the overflow is
reset to hidden.

## Fix Usecase
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/63583166/188386790-07b225c4-cd11-41eb-bd88-0f745952e9f8.png">

## What packages have been affected by this PR?
ui-toolkit

## Types of changes
New feature added in Accordion

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [ ] Bugfix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?
0.2.3


## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [x] Changes need to be immediately published on npm. 
