### PR TITLE
replaced classname rule with null in stylelint config

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -7,7 +7,6 @@ module.exports = {
   "rules": {
     "declaration-no-important": [true, { "severity": "warning" }],
     "rule-empty-line-before": ["always", { "severity": "warning" }],
-    "selector-class-pattern": null,
     "selector-id-pattern": null,
     "custom-property-pattern": null,
     "keyframes-name-pattern": null,

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -7,7 +7,7 @@ module.exports = {
   "rules": {
     "declaration-no-important": [true, { "severity": "warning" }],
     "rule-empty-line-before": ["always", { "severity": "warning" }],
-    "selector-class-pattern": ["\\w+\\d{2}\\w+", { "severity": "warning" }],
+    "selector-class-pattern": null,
     "selector-id-pattern": null,
     "custom-property-pattern": null,
     "keyframes-name-pattern": null,

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/stylelint-config",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Standard Stylelint config adopted in Groww. Customized as per requirement and preferences of devs in Groww.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What does this PR do?
Replaced classname selector rule with null, because we have migrated to next js and this rule no longer makes sense.



## What packages have been affected by this PR?
stylelint

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [ ] Bugfix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?



## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [x] Changes need to be immediately published on npm. 
