### PR TITLE
typescript version fixed to 4.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-react": "^7.23.1",
     "turbo": "latest",
-    "typescript": "^4.5.4"
+    "typescript": "4.5.5"
   },
   "engines": {
     "pnpm": ">=7.0.0",

--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -109,7 +109,7 @@
     "rollup-plugin-postcss": "^4.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript": "^1.0.1",
-    "typescript": "^4.2.4"
+    "typescript": "4.5.5"
   },
   "dependencies": {
     "@groww-tech/icon-store": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,19 +14,19 @@ importers:
       eslint-plugin-import: ^2.22.1
       eslint-plugin-react: ^7.23.1
       turbo: latest
-      typescript: ^4.5.4
+      typescript: 4.5.5
     devDependencies:
       '@groww-tech/eslint-config': link:packages/eslint-config
       '@groww-tech/eslint-plugin-internal': link:packages/eslint-plugin-internal
       '@groww-tech/tsconfig': link:packages/tsconfig
-      '@typescript-eslint/eslint-plugin': 4.33.0_s2qqtxhzmb7vugvfoyripfgp7i
-      '@typescript-eslint/parser': 4.33.0_jofidmxrjzhj7l6vknpw5ecvfe
+      '@typescript-eslint/eslint-plugin': 4.33.0_swkqfqhkeqhinvgsxkfyyd7oiu
+      '@typescript-eslint/parser': 4.33.0_sgaiclxgc5mltnpgmg7py4v6ca
       babel-eslint: 10.1.0_eslint@7.32.0
       eslint: 7.32.0
       eslint-plugin-import: 2.27.5_ffi3uiz42rv3jyhs6cr7p7qqry
       eslint-plugin-react: 7.32.2_eslint@7.32.0
       turbo: 1.8.6
-      typescript: 4.9.5
+      typescript: 4.5.5
 
   packages/analytics:
     specifiers:
@@ -314,7 +314,7 @@ importers:
       rollup-plugin-postcss: ^4.0.0
       rollup-plugin-terser: ^7.0.2
       rollup-plugin-typescript: ^1.0.1
-      typescript: ^4.2.4
+      typescript: 4.5.5
     dependencies:
       '@groww-tech/icon-store': link:../icon-store
       flat-carousel: 0.0.1
@@ -331,9 +331,9 @@ importers:
       '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.1
       '@stitches/react': 1.2.8_react@16.14.0
       '@storybook/addon-actions': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/addon-essentials': 6.5.16_gs6kq5b6zlr3wsbxecgofwr6aa
+      '@storybook/addon-essentials': 6.5.16_uyxre72upt6uoksvr4ujayweee
       '@storybook/addon-links': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/react': 6.5.16_gs6kq5b6zlr3wsbxecgofwr6aa
+      '@storybook/react': 6.5.16_uyxre72upt6uoksvr4ujayweee
       '@types/object-assign': 4.0.30
       '@types/react': 17.0.53
       '@types/react-dom': 17.0.19
@@ -356,8 +356,8 @@ importers:
       rollup-plugin-peer-deps-external: 2.2.4_rollup@2.79.1
       rollup-plugin-postcss: 4.0.2_postcss@8.4.21
       rollup-plugin-terser: 7.0.2_rollup@2.79.1
-      rollup-plugin-typescript: 1.0.1_typescript@4.9.5
-      typescript: 4.9.5
+      rollup-plugin-typescript: 1.0.1_typescript@4.5.5
+      typescript: 4.5.5
 
   packages/web-storage:
     specifiers:
@@ -2552,7 +2552,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-controls/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+  /@storybook/addon-controls/6.5.16_hbgkpkb7lq66soyez3d6ez7vdm:
     resolution: {integrity: sha512-kShSGjq1MjmmyL3l8i+uPz6yddtf82mzys0l82VKtcuyjrr5944wYFJ5NTXMfZxrO/U6FeFsfuFZE/k6ex3EMg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -2567,7 +2567,7 @@ packages:
       '@storybook/api': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/client-logger': 6.5.16
       '@storybook/components': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core-common': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.16
       '@storybook/store': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
@@ -2586,7 +2586,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs/6.5.16_gs6kq5b6zlr3wsbxecgofwr6aa:
+  /@storybook/addon-docs/6.5.16_uyxre72upt6uoksvr4ujayweee:
     resolution: {integrity: sha512-QM9WDZG9P02UvbzLu947a8ZngOrQeAKAT8jCibQFM/+RJ39xBlfm8rm+cQy3dm94wgtjmVkA3mKGOV/yrrsddg==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -2607,7 +2607,7 @@ packages:
       '@storybook/addons': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/api': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/components': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core-common': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       '@storybook/core-events': 6.5.16
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
@@ -2641,7 +2641,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.5.16_gs6kq5b6zlr3wsbxecgofwr6aa:
+  /@storybook/addon-essentials/6.5.16_uyxre72upt6uoksvr4ujayweee:
     resolution: {integrity: sha512-TeoMr6tEit4Pe91GH6f8g/oar1P4M0JL9S6oMcFxxrhhtOGO7XkWD5EnfyCx272Ok2VYfE58FNBTGPNBVIqYKQ==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -2701,15 +2701,15 @@ packages:
       '@babel/core': 7.21.3
       '@storybook/addon-actions': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/addon-backgrounds': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/addon-controls': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
-      '@storybook/addon-docs': 6.5.16_gs6kq5b6zlr3wsbxecgofwr6aa
+      '@storybook/addon-controls': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
+      '@storybook/addon-docs': 6.5.16_uyxre72upt6uoksvr4ujayweee
       '@storybook/addon-measure': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/addon-outline': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/addon-toolbars': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/addon-viewport': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/addons': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/api': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core-common': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       '@storybook/node-logger': 6.5.16
       core-js: 3.29.1
       react: 16.14.0
@@ -2897,7 +2897,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+  /@storybook/builder-webpack4/6.5.16_hbgkpkb7lq66soyez3d6ez7vdm:
     resolution: {integrity: sha512-YqDIrVNsUo8r9xc6AxsYDLxVYtMgl5Bxk+8/h1adsOko+jAFhdg6hOcAVxEmoSI0TMASOOVMFlT2hr23ppN2rQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -2915,7 +2915,7 @@ packages:
       '@storybook/client-api': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/client-logger': 6.5.16
       '@storybook/components': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core-common': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       '@storybook/core-events': 6.5.16
       '@storybook/node-logger': 6.5.16
       '@storybook/preview-web': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
@@ -2933,12 +2933,12 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_evijigonbo4skk2vlqtwtdqibu
+      fork-ts-checker-webpack-plugin: 4.1.6_ulm5vdg34btfvcm7osvrzev2ve
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.9.5
+      pnp-webpack-plugin: 1.6.4_typescript@4.5.5
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
@@ -2949,7 +2949,7 @@ packages:
       style-loader: 1.3.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 4.5.5
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -3051,7 +3051,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/core-client/6.5.16_agpnhhrqtlrjvu4wvv3uvxtnpi:
+  /@storybook/core-client/6.5.16_h4yukemzpu64bigjxy3voplx6u:
     resolution: {integrity: sha512-14IRaDrVtKrQ+gNWC0wPwkCNfkZOKghYV/swCUnQX3rP99defsZK8Hc7xHIYoAiOP5+sc3sweRAxgmFiJeQ1Ig==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3082,13 +3082,13 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 4.5.5
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 5.76.3
     dev: true
 
-  /@storybook/core-client/6.5.16_prilnw27wu4nsindseyg35liui:
+  /@storybook/core-client/6.5.16_zyeejxfrfuogpnrpbmu4nmghki:
     resolution: {integrity: sha512-14IRaDrVtKrQ+gNWC0wPwkCNfkZOKghYV/swCUnQX3rP99defsZK8Hc7xHIYoAiOP5+sc3sweRAxgmFiJeQ1Ig==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3119,13 +3119,13 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 4.5.5
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
     dev: true
 
-  /@storybook/core-common/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+  /@storybook/core-common/6.5.16_hbgkpkb7lq66soyez3d6ez7vdm:
     resolution: {integrity: sha512-2qtnKP3TTOzt2cp6LXKRTh7XrI9z5VanMnMTgeoFcA5ebnndD4V6BExQUdYPClE/QooLx6blUWNgS9dFEpjSqQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3169,7 +3169,7 @@ packages:
       express: 4.18.2
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3_evijigonbo4skk2vlqtwtdqibu
+      fork-ts-checker-webpack-plugin: 6.5.3_ulm5vdg34btfvcm7osvrzev2ve
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.7
@@ -3185,7 +3185,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 4.5.5
       util-deprecate: 1.0.2
       webpack: 4.46.0
     transitivePeerDependencies:
@@ -3202,7 +3202,7 @@ packages:
       core-js: 3.29.1
     dev: true
 
-  /@storybook/core-server/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+  /@storybook/core-server/6.5.16_hbgkpkb7lq66soyez3d6ez7vdm:
     resolution: {integrity: sha512-/3NPfmNyply395Dm0zaVZ8P9aruwO+tPx4D6/jpw8aqrRSwvAMndPMpoMCm0NXcpSm5rdX+Je4S3JW6JcggFkA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -3219,17 +3219,17 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
-      '@storybook/core-client': 6.5.16_prilnw27wu4nsindseyg35liui
-      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/builder-webpack4': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
+      '@storybook/core-client': 6.5.16_zyeejxfrfuogpnrpbmu4nmghki
+      '@storybook/core-common': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       '@storybook/core-events': 6.5.16
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.16
-      '@storybook/manager-webpack4': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/manager-webpack4': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       '@storybook/node-logger': 6.5.16
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/telemetry': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/telemetry': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       '@types/node': 16.18.21
       '@types/node-fetch': 2.6.2
       '@types/pretty-hrtime': 1.0.1
@@ -3260,7 +3260,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 4.5.5
       util-deprecate: 1.0.2
       watchpack: 2.4.0
       webpack: 4.46.0
@@ -3279,7 +3279,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.16_agpnhhrqtlrjvu4wvv3uvxtnpi:
+  /@storybook/core/6.5.16_h4yukemzpu64bigjxy3voplx6u:
     resolution: {integrity: sha512-CEF3QFTsm/VMnMKtRNr4rRdLeIkIG0g1t26WcmxTdSThNPBd8CsWzQJ7Jqu7CKiut+MU4A1LMOwbwCE5F2gmyA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -3296,11 +3296,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.5.16_agpnhhrqtlrjvu4wvv3uvxtnpi
-      '@storybook/core-server': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core-client': 6.5.16_h4yukemzpu64bigjxy3voplx6u
+      '@storybook/core-server': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
-      typescript: 4.9.5
+      typescript: 4.5.5
       webpack: 5.76.3
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -3363,7 +3363,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/manager-webpack4/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+  /@storybook/manager-webpack4/6.5.16_hbgkpkb7lq66soyez3d6ez7vdm:
     resolution: {integrity: sha512-5VJZwmQU6AgdsBPsYdu886UKBHQ9SJEnFMaeUxKEclXk+iRsmbzlL4GHKyVd6oGX/ZaecZtcHPR6xrzmA4Ziew==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3377,8 +3377,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.21.3
       '@babel/preset-react': 7.18.6_@babel+core@7.21.3
       '@storybook/addons': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-client': 6.5.16_prilnw27wu4nsindseyg35liui
-      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core-client': 6.5.16_zyeejxfrfuogpnrpbmu4nmghki
+      '@storybook/core-common': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       '@storybook/node-logger': 6.5.16
       '@storybook/theming': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/ui': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
@@ -3395,7 +3395,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.9
-      pnp-webpack-plugin: 1.6.4_typescript@4.9.5
+      pnp-webpack-plugin: 1.6.4_typescript@4.5.5
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
       read-pkg-up: 7.0.1
@@ -3405,7 +3405,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 4.5.5
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -3482,7 +3482,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_t37drsge5fnqkss6ynqsf64hyi:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_4fz5o4jqu2izslsdobabeqat3u:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -3493,15 +3493,15 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2_typescript@4.9.5
+      react-docgen-typescript: 2.2.2_typescript@4.5.5
       tslib: 2.5.0
-      typescript: 4.9.5
+      typescript: 4.5.5
       webpack: 5.76.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react/6.5.16_gs6kq5b6zlr3wsbxecgofwr6aa:
+  /@storybook/react/6.5.16_uyxre72upt6uoksvr4ujayweee:
     resolution: {integrity: sha512-cBtNlOzf/MySpNLBK22lJ8wFU22HnfTB2xJyBk7W7Zi71Lm7Uxkhv1Pz8HdiQndJ0SlsAAQOWjQYsSZsGkZIaA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -3535,12 +3535,12 @@ packages:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_l5xlphlxntgn25bvkswgojnsh4
       '@storybook/addons': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/client-logger': 6.5.16
-      '@storybook/core': 6.5.16_agpnhhrqtlrjvu4wvv3uvxtnpi
-      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core': 6.5.16_h4yukemzpu64bigjxy3voplx6u
+      '@storybook/core-common': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/node-logger': 6.5.16
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_t37drsge5fnqkss6ynqsf64hyi
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_4fz5o4jqu2izslsdobabeqat3u
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@types/estree': 0.0.51
@@ -3565,7 +3565,7 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.9.5
+      typescript: 4.5.5
       util-deprecate: 1.0.2
       webpack: 5.76.3
     transitivePeerDependencies:
@@ -3659,11 +3659,11 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/telemetry/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+  /@storybook/telemetry/6.5.16_hbgkpkb7lq66soyez3d6ez7vdm:
     resolution: {integrity: sha512-CWr5Uko1l9jJW88yTXsZTj/3GTabPvw0o7pDPOXPp8JRZiJTxv1JFaFCafhK9UzYbgcRuGfCC8kEWPZims7iKA==}
     dependencies:
       '@storybook/client-logger': 6.5.16
-      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core-common': 6.5.16_hbgkpkb7lq66soyez3d6ez7vdm
       chalk: 4.1.2
       core-js: 3.29.1
       detect-package-manager: 2.0.1
@@ -4269,7 +4269,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.33.0_s2qqtxhzmb7vugvfoyripfgp7i:
+  /@typescript-eslint/eslint-plugin/4.33.0_swkqfqhkeqhinvgsxkfyyd7oiu:
     resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -4280,8 +4280,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0_jofidmxrjzhj7l6vknpw5ecvfe
-      '@typescript-eslint/parser': 4.33.0_jofidmxrjzhj7l6vknpw5ecvfe
+      '@typescript-eslint/experimental-utils': 4.33.0_sgaiclxgc5mltnpgmg7py4v6ca
+      '@typescript-eslint/parser': 4.33.0_sgaiclxgc5mltnpgmg7py4v6ca
       '@typescript-eslint/scope-manager': 4.33.0
       debug: 4.3.4
       eslint: 7.32.0
@@ -4289,8 +4289,8 @@ packages:
       ignore: 5.2.4
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.5
-      typescript: 4.9.5
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4313,7 +4313,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.33.0_jofidmxrjzhj7l6vknpw5ecvfe:
+  /@typescript-eslint/experimental-utils/4.33.0_sgaiclxgc5mltnpgmg7py4v6ca:
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -4322,7 +4322,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.5.5
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.32.0
@@ -4367,7 +4367,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/4.33.0_jofidmxrjzhj7l6vknpw5ecvfe:
+  /@typescript-eslint/parser/4.33.0_sgaiclxgc5mltnpgmg7py4v6ca:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -4379,10 +4379,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.5.5
       debug: 4.3.4
       eslint: 7.32.0
-      typescript: 4.9.5
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4435,6 +4435,27 @@ packages:
       is-glob: 4.0.3
       semver: 7.3.8
       tsutils: 3.21.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/4.33.0_typescript@4.5.5:
+    resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 4.33.0
+      '@typescript-eslint/visitor-keys': 4.33.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7801,7 +7822,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0_jofidmxrjzhj7l6vknpw5ecvfe
+      '@typescript-eslint/parser': 4.33.0_sgaiclxgc5mltnpgmg7py4v6ca
       debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.7
@@ -7829,7 +7850,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0_jofidmxrjzhj7l6vknpw5ecvfe
+      '@typescript-eslint/parser': 4.33.0_sgaiclxgc5mltnpgmg7py4v6ca
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -8554,7 +8575,7 @@ packages:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: true
 
-  /fork-ts-checker-webpack-plugin/4.1.6_evijigonbo4skk2vlqtwtdqibu:
+  /fork-ts-checker-webpack-plugin/4.1.6_ulm5vdg34btfvcm7osvrzev2ve:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -8574,14 +8595,14 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.9.5
+      typescript: 4.5.5
       webpack: 4.46.0
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.3_evijigonbo4skk2vlqtwtdqibu:
+  /fork-ts-checker-webpack-plugin/6.5.3_ulm5vdg34btfvcm7osvrzev2ve:
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -8608,7 +8629,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.8
       tapable: 1.1.3
-      typescript: 4.9.5
+      typescript: 4.5.5
       webpack: 4.46.0
     dev: true
 
@@ -12041,11 +12062,11 @@ packages:
       pathe: 1.1.0
     dev: true
 
-  /pnp-webpack-plugin/1.6.4_typescript@4.9.5:
+  /pnp-webpack-plugin/1.6.4_typescript@4.5.5:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.9.5
+      ts-pnp: 1.2.0_typescript@4.5.5
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -12857,12 +12878,12 @@ packages:
       webpack: 4.46.0
     dev: true
 
-  /react-docgen-typescript/2.2.2_typescript@4.9.5:
+  /react-docgen-typescript/2.2.2_typescript@4.5.5:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.9.5
+      typescript: 4.5.5
     dev: true
 
   /react-docgen/5.4.3:
@@ -13574,7 +13595,7 @@ packages:
       terser: 5.16.8
     dev: true
 
-  /rollup-plugin-typescript/1.0.1_typescript@4.9.5:
+  /rollup-plugin-typescript/1.0.1_typescript@4.5.5:
     resolution: {integrity: sha512-rwJDNn9jv/NsKZuyBb/h0jsclP4CJ58qbvZt2Q9zDIGILF2LtdtvCqMOL+Gq9IVq5MTrTlHZNrn8h7VjQgd8tw==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-typescript.
     peerDependencies:
@@ -13583,7 +13604,7 @@ packages:
     dependencies:
       resolve: 1.22.1
       rollup-pluginutils: 2.8.2
-      typescript: 4.9.5
+      typescript: 4.5.5
     dev: true
 
   /rollup-pluginutils/2.8.2:
@@ -15001,7 +15022,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-pnp/1.2.0_typescript@4.9.5:
+  /ts-pnp/1.2.0_typescript@4.5.5:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -15010,7 +15031,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.9.5
+      typescript: 4.5.5
     dev: true
 
   /tsconfig-paths/3.14.2:
@@ -15102,6 +15123,16 @@ packages:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
+    dev: true
+
+  /tsutils/3.21.0_typescript@4.5.5:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.5.5
     dev: true
 
   /tsutils/3.21.0_typescript@4.9.5:
@@ -15265,6 +15296,12 @@ packages:
 
   /typescript/4.4.4:
     resolution: {integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript/4.5.5:
+    resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
## What does this PR do?
We have a dependency in package.json for ui-toolkit to support typescript with minor version ^4.4.2
This was causing ui-toolkit to install typescript version of 4.9.5 on ci/cd during github workflow action causing types to fail.


## What packages have been affected by this PR?
ui-toolkit

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [ ] Bugfix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?



## Checklist before merging

_Put an `x` in the boxes that apply_

- [ ] These changes have been thoroughly tested.

- [ ] Changes need to be immediately published on npm. 
