### PR TITLE
Refactored inappropriate eslint declaration practice and variable naming in package ella / src / number

### DIFF
--- a/packages/ella/src/number/index.ts
+++ b/packages/ella/src/number/index.ts
@@ -390,15 +390,15 @@ export function toFixedWithoutRounding(num: number | string, toFixedDecimal: num
       return num;
     }
 
-    let number = num.toString();
+    const numString = num.toString();
 
-    const decimalIndex = number.indexOf('.');
+    const decimalIndex = numString.indexOf('.');
 
     if (decimalIndex === -1 || toFixedDecimal < 0) {
-      return number;
+      return numString;
     }
 
-    return number.slice(0, (decimalIndex + (toFixedDecimal + 1)));
+    return numString.slice(0, (decimalIndex + (toFixedDecimal + 1)));
 
   } catch (err) {
     console.error('Error in rounding off number ', err);

--- a/packages/ella/src/number/index.ts
+++ b/packages/ella/src/number/index.ts
@@ -107,7 +107,7 @@ export function isValidMobileNumber(mobNumber: number | string) {
  * ```
  */
 export function convertPaisaToRupee(value: number | string) {
-   return parseFloat(value as string) / 100;
+  return parseFloat(value as string) / 100;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?
Improves an eslint declaration from `let` to `const` for a variable which wasn't being reassigned in a function. And also changed the variable's name from `number` to `numString` because `number` is also a typescript type being used in the same function and `numString` is more accurate based on the logic.


## What packages have been affected by this PR?
ella


## Types of changes
Refactoring for better naming and declaration practices.

Before:
![image](https://user-images.githubusercontent.com/85788367/233061094-5c533b9d-65af-4f54-9798-f66e8db661cd.png)

After: No problems detected in workspace.

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [x] Bugfix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?



## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [ ] Changes need to be immediately published on npm. 
