### PR TITLE
fixed ui toolkit dep size increased unconditionally

### DIFF
--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -70,7 +70,8 @@
     "prop-types": "^15.7.2",
     "react": "^16.12.0 || ^17.0.0",
     "react-dom": "^16.12.0 || ^17.0.0",
-    "react-lazyload": "^3.0.0"
+    "react-lazyload": "^3.0.0",
+    "@groww-tech/icon-store": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.13.15",
@@ -109,10 +110,11 @@
     "rollup-plugin-postcss": "^4.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript": "^1.0.1",
-    "typescript": "4.5.5"
+    "typescript": "4.5.5",
+    "rollup-plugin-visualizer": "latest",
+    "@groww-tech/icon-store": "workspace:*"
   },
   "dependencies": {
-    "@groww-tech/icon-store": "workspace:*",
     "flat-carousel": "0.0.1",
     "lodash.debounce": "^4.0.8",
     "react-waypoint": "^10.1.0"

--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -111,7 +111,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript": "^1.0.1",
     "typescript": "4.5.5",
-    "@groww-tech/icon-store": "workspace:*"
+    "@groww-tech/icon-store": "1.3.0"
   },
   "dependencies": {
     "flat-carousel": "0.0.1",

--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/ui-toolkit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A lightning nature UI",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -111,7 +111,6 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript": "^1.0.1",
     "typescript": "4.5.5",
-    "rollup-plugin-visualizer": "latest",
     "@groww-tech/icon-store": "workspace:*"
   },
   "dependencies": {

--- a/packages/ui-toolkit/rollup.config.js
+++ b/packages/ui-toolkit/rollup.config.js
@@ -7,6 +7,7 @@ import external from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
@@ -41,6 +42,10 @@ const commonConfig = {
       targets: [
         { src: 'src/types', dest: 'dist' }
       ]
+    }),
+    visualizer({
+      emitFile: true,
+      filename: 'stats.html'
     })
   ],
   external: [ 'react', 'react-dom', 'classnames', 'react-lazyload' ]

--- a/packages/ui-toolkit/rollup.config.js
+++ b/packages/ui-toolkit/rollup.config.js
@@ -7,7 +7,6 @@ import external from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript';
-import { visualizer } from 'rollup-plugin-visualizer';
 
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
@@ -42,10 +41,6 @@ const commonConfig = {
       targets: [
         { src: 'src/types', dest: 'dist' }
       ]
-    }),
-    visualizer({
-      emitFile: true,
-      filename: 'stats.html'
     })
   ],
   external: [ 'react', 'react-dom', 'classnames', 'react-lazyload' ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,7 +316,6 @@ importers:
       rollup-plugin-postcss: ^4.0.0
       rollup-plugin-terser: ^7.0.2
       rollup-plugin-typescript: ^1.0.1
-      rollup-plugin-visualizer: latest
       typescript: 4.5.5
     dependencies:
       flat-carousel: 0.0.1
@@ -360,7 +359,6 @@ importers:
       rollup-plugin-postcss: 4.0.2_postcss@8.4.21
       rollup-plugin-terser: 7.0.2_rollup@2.79.1
       rollup-plugin-typescript: 1.0.1_typescript@4.5.5
-      rollup-plugin-visualizer: 5.9.0_rollup@2.79.1
       typescript: 4.5.5
 
   packages/web-storage:
@@ -6207,15 +6205,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  /cliui/8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    dev: true
 
   /clone-deep/4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -13601,23 +13590,6 @@ packages:
       typescript: 4.5.5
     dev: true
 
-  /rollup-plugin-visualizer/5.9.0_rollup@2.79.1:
-    resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
-    engines: {node: '>=14'}
-    hasBin: true
-    peerDependencies:
-      rollup: 2.x || 3.x
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      open: 8.4.2
-      picomatch: 2.3.1
-      rollup: 2.79.1
-      source-map: 0.7.4
-      yargs: 17.7.1
-    dev: true
-
   /rollup-pluginutils/2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
@@ -16271,11 +16243,6 @@ packages:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
 
-  /yargs-parser/21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-    dev: true
-
   /yargs-unparser/1.6.0:
     resolution: {integrity: sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==}
     engines: {node: '>=6'}
@@ -16311,19 +16278,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
-
-  /yargs/17.7.1:
-    resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
-    dev: true
 
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,9 +316,9 @@ importers:
       rollup-plugin-postcss: ^4.0.0
       rollup-plugin-terser: ^7.0.2
       rollup-plugin-typescript: ^1.0.1
+      rollup-plugin-visualizer: latest
       typescript: 4.5.5
     dependencies:
-      '@groww-tech/icon-store': link:../icon-store
       flat-carousel: 0.0.1
       lodash.debounce: 4.0.8
       react-waypoint: 10.3.0_react@16.14.0
@@ -329,6 +329,7 @@ importers:
       '@babel/preset-react': 7.18.6_@babel+core@7.21.3
       '@babel/preset-typescript': 7.21.0_@babel+core@7.21.3
       '@groww-tech/base-css': link:../base-css
+      '@groww-tech/icon-store': link:../icon-store
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.79.1
       '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.1
       '@stitches/react': 1.2.8_react@16.14.0
@@ -359,6 +360,7 @@ importers:
       rollup-plugin-postcss: 4.0.2_postcss@8.4.21
       rollup-plugin-terser: 7.0.2_rollup@2.79.1
       rollup-plugin-typescript: 1.0.1_typescript@4.5.5
+      rollup-plugin-visualizer: 5.9.0_rollup@2.79.1
       typescript: 4.5.5
 
   packages/web-storage:
@@ -6205,6 +6207,15 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  /cliui/8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
 
   /clone-deep/4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -13590,6 +13601,23 @@ packages:
       typescript: 4.5.5
     dev: true
 
+  /rollup-plugin-visualizer/5.9.0_rollup@2.79.1:
+    resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      rollup: 2.x || 3.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      open: 8.4.2
+      picomatch: 2.3.1
+      rollup: 2.79.1
+      source-map: 0.7.4
+      yargs: 17.7.1
+    dev: true
+
   /rollup-pluginutils/2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
@@ -16243,6 +16271,11 @@ packages:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
 
+  /yargs-parser/21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /yargs-unparser/1.6.0:
     resolution: {integrity: sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==}
     engines: {node: '>=6'}
@@ -16278,6 +16311,19 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
+
+  /yargs/17.7.1:
+    resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+    dev: true
 
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
       '@babel/preset-react': ^7.13.13
       '@babel/preset-typescript': ^7.13.0
       '@groww-tech/base-css': workspace:*
-      '@groww-tech/icon-store': workspace:*
+      '@groww-tech/icon-store': 1.3.0
       '@rollup/plugin-commonjs': ^19.0.0
       '@rollup/plugin-node-resolve': ^11.2.1
       '@stitches/react': ^1.2.7
@@ -328,7 +328,7 @@ importers:
       '@babel/preset-react': 7.18.6_@babel+core@7.21.3
       '@babel/preset-typescript': 7.21.0_@babel+core@7.21.3
       '@groww-tech/base-css': link:../base-css
-      '@groww-tech/icon-store': link:../icon-store
+      '@groww-tech/icon-store': 1.3.0_react@16.14.0
       '@rollup/plugin-commonjs': 19.0.2_rollup@2.79.1
       '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.1
       '@stitches/react': 1.2.8_react@16.14.0
@@ -2137,6 +2137,14 @@ packages:
       lodash.isequal: 4.5.0
       react-helmet: 6.1.0
     dev: false
+
+  /@groww-tech/icon-store/1.3.0_react@16.14.0:
+    resolution: {integrity: sha512-DN8DGO8oXDVomV7BaUmF6Kp2Fv1bJID3ABjWz2Pq+JV06piYGM/0nKWu+2yD7C+VtDguHK9dDHs+uGdbsH+weA==}
+    peerDependencies:
+      react: ^16.12.0
+    dependencies:
+      react: 16.14.0
+    dev: true
 
   /@humanwhocodes/config-array/0.5.0:
     resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
@@ -8734,7 +8742,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0


### PR DESCRIPTION
## What does this PR do?
ui-toolkit had @groww-tech/icon-store in dependencies.
This was causing it to bundle entire icon-store along with the main package.

This increased the bundle size from 66kb -> ~234kb

This Pr fixes the above issue by making the icon-store package a peerDep and
adding icon-store in devDependencies.



## What packages have been affected by this PR?
ui-toolkit

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [x] Bugfix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?
0.3.1 -> 0.3.2 (ui-toolkit)


## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [x] Changes need to be immediately published on npm. 
