### PR TITLE
fix/ secondary BG fix

### DIFF
--- a/packages/base-css/dist/theme.css
+++ b/packages/base-css/dist/theme.css
@@ -49,6 +49,7 @@ html {
   --constantSecondaryClr10: #F6F6F7;
   --cardBackground: #FFF;
  --mintSecondaryBackground: #1B1B1B;
+ --mintSecondaryBg: #F8F8F8;
 }
 
 html[data-theme="dark"] {
@@ -94,4 +95,5 @@ html[data-theme="dark"] {
   --constantSecondaryClr10: #2A2A2A;
   --cardBackground: #1D1D1D;
   --mintSecondaryBackground: #F8F8F8;
+  --mintSecondaryBg: #1B1B1B;
 }

--- a/packages/base-css/package.json
+++ b/packages/base-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/base-css",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Base CSS classes used by all Groww Web Projects",
   "main": "dist/index.css",
   "files": [


### PR DESCRIPTION
## What does this PR do?

Currently there is no support for secondary background in our library for light mode, its #FFF for both primary and secondary background. 
`mintSecondaryBackground` was added to support that but it was inverted in [PR237](https://github.com/Groww/webster/pull/237/files), light mode has dark secondaryBg and dark mode has light secondaryBg.
This PR adds `mintSecondaryBg` as new variable, which enables us to use #F8F8F8


## What packages have been affected by this PR?

base-css

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [ ] Bugfix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?

0.0.7 to 0.0.8 for base-css

## Checklist before merging

_Put an `x` in the boxes that apply_

- [ ] These changes have been thoroughly tested.

- [ ] Changes need to be immediately published on npm. 
