### PR TITLE
(fix): ui-toolkit - Calendar functionality and styling 

### DIFF
--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/ui-toolkit",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A lightning nature UI",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ui-toolkit/src/components/molecules/Calendar/Calendar.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/Calendar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import MonthCalendar from './MonthCalendar';
 import DateCalendar from './DateCalendar';
+import { CalendarProps } from './calendar.types';
 
 export const CALENDAR_TYPE = {
   MONTH: 'MONTH',
@@ -22,34 +23,22 @@ const Calendar = (props:Props) => {
 
   const emptyFunction = () => void 0;
 
-  if (type === CALENDAR_TYPE.MONTH) {
+  const CalendarComponent = type === 'MONTH' ? MonthCalendar : DateCalendar;
 
-    return (
-      <MonthCalendar currentDate={currentDate || new Date()}
-        onDateChange={onDateChange || emptyFunction}
-      />
-    );
-
-  } else if (type === CALENDAR_TYPE.DATE) {
-    return (
-      <DateCalendar
-        minDate={minDate}
-        maxDate={maxDate}
-        onDateChange={onDateChange || emptyFunction}
-        currentDate={currentDate || new Date()}
-        highlightCurrentDate={highlightCurrentDate}
-      />
-    );
-
-  }
-
-  return <div />;
+  return (
+    <CalendarComponent
+      currentDate={currentDate || new Date()}
+      minDate={minDate}
+      maxDate={maxDate}
+      onDateChange={onDateChange || emptyFunction}
+      highlightCurrentDate={highlightCurrentDate}
+    />
+  );
 };
 
 
 export type Props = {
-  type: ValueOf<typeof CALENDAR_TYPE>;
-} & Partial<React.ComponentProps<typeof MonthCalendar>>
-& Partial<React.ComponentProps<typeof DateCalendar>>;
+  type: keyof typeof CALENDAR_TYPE;
+} & CalendarProps;
 
 export default Calendar;

--- a/packages/ui-toolkit/src/components/molecules/Calendar/Calendar.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/Calendar.tsx
@@ -23,7 +23,7 @@ const Calendar = (props:Props) => {
 
   const emptyFunction = () => void 0;
 
-  const CalendarComponent = type === 'MONTH' ? MonthCalendar : DateCalendar;
+  const CalendarComponent = type === CALENDAR_TYPE.MONTH ? MonthCalendar : DateCalendar;
 
   return (
     <CalendarComponent

--- a/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/dateCalendar.css
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/dateCalendar.css
@@ -5,12 +5,7 @@
   cursor: auto;
 }
 
-.cc12YearBox {
-  justify-content: space-between;
-}
-
 .cc12WeekNameBox {
-  justify-content: space-between;
   margin-top: 14px;
   text-align: center;
 }
@@ -39,10 +34,6 @@
 
 .cc12DateCurrent {
   background: var(--green300);
-}
-
-.cc12DateSelected {
-  background: var(--green500);
 }
 
 .cc12DateRow {

--- a/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/dateCalendar.css
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/dateCalendar.css
@@ -32,12 +32,17 @@
 
 .cc12DateNotSelected {}
 
-.cc12DateSelected {
-  background: var(--green500);
-}
-
+/* NOTE: Here below order matters as active, hover state color override */
 .cc12DateNotSelected:hover {
   background: var(--overlay30);
+}
+
+.cc12DateCurrent {
+  background: var(--green300);
+}
+
+.cc12DateSelected {
+  background: var(--green500);
 }
 
 .cc12DateRow {
@@ -52,4 +57,5 @@
 
 .cc12DisableDate {
   opacity: 0.2;
+  cursor: default;
 }

--- a/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx
@@ -65,54 +65,49 @@ class DateCalendar extends React.PureComponent<Props, State> {
     const hasNextMonth = !(maxDate && dateToShow.getMonth() === maxDate.getMonth() && dateToShow.getFullYear() === maxDate.getFullYear());
     const hasPrevMonth = !(minDate && dateToShow.getMonth() === minDate.getMonth() && dateToShow.getFullYear() === minDate.getFullYear());
 
+    const handlers = {
+      'PREVIOUS_YEAR': () => {
+        if (hasPrevYear) this.goToPreviousYear();
+      },
+      'PREVIOUS_MONTH': () => {
+        if (hasPrevMonth) this.goToPreviousMonth();
+      },
+      'NEXT_MONTH': () => {
+        if (hasNextMonth) this.goToNextMonth();
+      },
+      'NEXT_YEAR': () => {
+        if (hasNextYear) this.goToNextYear();
+      }
+    };
+
     return (
       <div className="valign-wrapper cc12YearBox">
         <div className="valign-wrapper cur-po">
           <KeyboardDoubleArrowLeft
             fontSize={21}
-            onClick={
-              () => {
-                if (hasPrevYear) this.goToPreviousYear();
-              }
-            }
+            onClick={handlers.PREVIOUS_YEAR}
             className={cn({ 'contentSecondary cur-no': !hasPrevYear })}
           />
         </div>
-        <div
-          className="valign-wrapper cur-po"
-        >
+        <div className="valign-wrapper cur-po">
           <KeyboardArrowLeft fontSize={21}
-            onClick={
-              () => {
-                if (hasPrevMonth) this.goToPreviousMonth();
-              }
-            }
+            onClick={handlers.PREVIOUS_MONTH}
             className={cn({ 'contentSecondary cur-no': !hasPrevMonth })}
           />
         </div>
         <div className='cc12Year bodyRegular16'>
           <span>{getMonthAbbrByIndex(dateToShow.getMonth() + 1)} {dateToShow.getFullYear()}</span>
         </div>
-        <div
-          className="valign-wrapper cur-po"
-        >
+        <div className="valign-wrapper cur-po">
           <KeyboardArrowRight fontSize={21}
-            onClick={
-              () => {
-                if (hasNextMonth) this.goToNextMonth();
-              }
-            }
+            onClick={handlers.NEXT_MONTH}
             className={cn({ 'contentSecondary cur-no': !hasNextMonth })}
           />
         </div>
         <div className="valign-wrapper cur-po">
           <KeyboardDoubleArrowRight
             fontSize={21}
-            onClick={
-              () => {
-                if (hasNextYear) this.goToNextYear();
-              }
-            }
+            onClick={handlers.NEXT_YEAR}
             className={cn({ 'contentSecondary cur-no': !hasNextYear })}
           />
         </div>

--- a/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx
@@ -157,6 +157,11 @@ class DateCalendar extends React.PureComponent<Props, State> {
                       const dateSelected = newDate.getTime() === selectedDate?.getTime();
                       const isDisabled = (minDate && compareDate(minDate, newDate)) || (maxDate && compareDate(newDate, maxDate));
 
+
+                      const onClickHandler = () => {
+                        if (!isDisabled) this.onDateClick(date);
+                      };
+
                       return (
                         <div className="cc12DateBlock"
                           key={`${newDate.getTime()}${index}`}
@@ -170,11 +175,7 @@ class DateCalendar extends React.PureComponent<Props, State> {
                                 'cc12DisableDate': isDisabled
                               })
                             }
-                            onClick={
-                              () => {
-                                if (!isDisabled) this.onDateClick(date);
-                              }
-                            }
+                            onClick={onClickHandler}
                           >
                             {date}
                           </span>
@@ -182,6 +183,7 @@ class DateCalendar extends React.PureComponent<Props, State> {
                       );
                     }
 
+                    // NOTE: Renders the empty date block or date offsets
                     return (
                       <div className="cc12DateBlock"
                         key={index}

--- a/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx
@@ -7,7 +7,8 @@ import {
   KeyboardDoubleArrowRight
 } from '@groww-tech/icon-store/mi';
 
-import { getDatesArray, getMonthAbbrByIndex } from './dateCalendarUtils';
+import { compareDate, getDatesArray, getMonthAbbrByIndex } from '../calendarUtils';
+import { CalendarProps as Props } from '../calendar.types';
 
 import './dateCalendar.css';
 
@@ -16,7 +17,7 @@ const WEEK_DAYS = [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ];
 
 class DateCalendar extends React.PureComponent<Props, State> {
   static defaultProps = {
-    highlightCurrentDate: false,
+    highlightCurrentDate: true,
     minDate: null,
     maxDate: null
   };
@@ -24,12 +25,14 @@ class DateCalendar extends React.PureComponent<Props, State> {
 
   state:State = {
     dateToShow: this.props.currentDate,
-    dates: getDatesArray(this.props.currentDate)
+    dates: getDatesArray(this.props.currentDate),
+    selectedDate: null
   };
 
 
   componentDidUpdate(prevProps: Props) {
-    if (prevProps.currentDate.getDate() != this.props.currentDate.getDate()) {
+
+    if (prevProps.currentDate.getDate() !== this.props.currentDate.getDate()) {
       this.setState({
         dateToShow: this.props.currentDate,
         dates: getDatesArray(this.props.currentDate)
@@ -43,15 +46,9 @@ class DateCalendar extends React.PureComponent<Props, State> {
     return (
       <div>
         <div className="cc12Box">
-          <div>
-            {this.getYearUI()}
-          </div>
-          <div>
-            {this.getMonthUI()}
-          </div>
-          <div>
-            {this.getDatesUI()}
-          </div>
+          {this.getYearUI()}
+          {this.getMonthUI()}
+          {this.getDatesUI()}
         </div>
       </div>
     );
@@ -60,35 +57,64 @@ class DateCalendar extends React.PureComponent<Props, State> {
 
   getYearUI = () => {
     const { dateToShow } = this.state;
+    const maxDate = this.props.maxDate ? new Date(this.props.maxDate) : null;
+    const minDate = this.props.minDate ? new Date(this.props.minDate) : null;
+
+    const hasNextYear = !(maxDate && dateToShow.getFullYear() === maxDate.getFullYear());
+    const hasPrevYear = !(minDate && dateToShow.getFullYear() === minDate.getFullYear());
+    const hasNextMonth = !(maxDate && dateToShow.getMonth() === maxDate.getMonth() && dateToShow.getFullYear() === maxDate.getFullYear());
+    const hasPrevMonth = !(minDate && dateToShow.getMonth() === minDate.getMonth() && dateToShow.getFullYear() === minDate.getFullYear());
 
     return (
-      <div>
-        <div className="valign-wrapper cc12YearBox">
-          <div className="valign-wrapper cur-po">
-            <KeyboardDoubleArrowLeft
-              fontSize={21}
-              onClick={this.goToPreviousYear}
-            />
-          </div>
-          <div onClick={this.goToPreviousMonth}
-            className="valign-wrapper cur-po"
-          >
-            <KeyboardArrowLeft fontSize={21} />
-          </div>
-          <div className='cc12Year bodyRegular16'>
-            <div>{getMonthAbbrByIndex(dateToShow.getMonth() + 1)} {dateToShow.getFullYear()}</div>
-          </div>
-          <div onClick={this.goToNextMonth}
-            className="valign-wrapper cur-po"
-          >
-            <KeyboardArrowRight fontSize={21} />
-          </div>
-          <div className="valign-wrapper cur-po">
-            <KeyboardDoubleArrowRight
-              fontSize={21}
-              onClick={this.goToNextYear}
-            />
-          </div>
+      <div className="valign-wrapper cc12YearBox">
+        <div className="valign-wrapper cur-po">
+          <KeyboardDoubleArrowLeft
+            fontSize={21}
+            onClick={
+              () => {
+                if (hasPrevYear) this.goToPreviousYear();
+              }
+            }
+            className={cn({ 'contentSecondary cur-no': !hasPrevYear })}
+          />
+        </div>
+        <div
+          className="valign-wrapper cur-po"
+        >
+          <KeyboardArrowLeft fontSize={21}
+            onClick={
+              () => {
+                if (hasPrevMonth) this.goToPreviousMonth();
+              }
+            }
+            className={cn({ 'contentSecondary cur-no': !hasPrevMonth })}
+          />
+        </div>
+        <div className='cc12Year bodyRegular16'>
+          <span>{getMonthAbbrByIndex(dateToShow.getMonth() + 1)} {dateToShow.getFullYear()}</span>
+        </div>
+        <div
+          className="valign-wrapper cur-po"
+        >
+          <KeyboardArrowRight fontSize={21}
+            onClick={
+              () => {
+                if (hasNextMonth) this.goToNextMonth();
+              }
+            }
+            className={cn({ 'contentSecondary cur-no': !hasNextMonth })}
+          />
+        </div>
+        <div className="valign-wrapper cur-po">
+          <KeyboardDoubleArrowRight
+            fontSize={21}
+            onClick={
+              () => {
+                if (hasNextYear) this.goToNextYear();
+              }
+            }
+            className={cn({ 'contentSecondary cur-no': !hasNextYear })}
+          />
         </div>
       </div>
     );
@@ -97,74 +123,81 @@ class DateCalendar extends React.PureComponent<Props, State> {
 
   getMonthUI = () => {
     return (
-      (<div>
-        <div className='cc12WeekNameBox valign-wrapper contentSecondary bodyRegular14'>
-          {
-            WEEK_DAYS.map(day => (
-              <div className="cc12WeekName">
-                <div>
-                  {day}
-                </div>
-              </div>
-            ))
-          }
-        </div>
-      </div>)
+      <div className='cc12WeekNameBox valign-wrapper contentSecondary bodyRegular14'>
+        {
+          WEEK_DAYS.map((day) => (
+            <span className="cc12WeekName"
+              key={day}
+            >
+              {day}
+            </span>
+          ))
+        }
+      </div>
     );
   }
 
 
   getDatesUI = () => {
-    const { dates, dateToShow } = this.state;
+    const { dates, dateToShow, selectedDate } = this.state;
     const { minDate, maxDate } = this.props;
 
     return (
       <div>
-        <div>
-          {
-            dates.map((dateArr, datesArrIndex) => {
-              return (
-                <div
-                  key={'datesArrIndex' + datesArrIndex}
-                  className="valign-wrapper cc12DateRow"
-                >
-                  {
-                    dateArr.map((date) => {
-                      if (date !== null) {
-                        const newDate = new Date(dateToShow);
+        {
+          dates.map((dateArr, datesArrIndex) => {
 
-                        newDate.setDate(date);
+            return (
+              <div
+                key={'datesArrIndex' + datesArrIndex}
+                className="valign-wrapper cc12DateRow"
+              >
+                {
+                  dateArr.map((date, index) => {
+                    if (date !== null) {
+                      const newDate = new Date(dateToShow);
 
-                        const dateSelected = this.isDateSelected(date);
+                      newDate.setDate(date);
 
-                        return (
-                          (<div className="cc12DateBlock">
-                            <div
-                              className={
-                                cn('cc12Date valign-wrapper cur-po circle bodyRegular14', {
-                                  'cc12DateNotSelected': !dateSelected,
-                                  'cc12DateSelected contentInversePrimary': dateSelected,
-                                  'cc12DisableDate': (minDate && this.compareDate(minDate, newDate)) || (maxDate && this.compareDate(newDate, maxDate))
-                                })
-                              }
-                              onClick={() => this.onDateClick(date)}
-                            >
-                              {date}
-                            </div>
-                          </div>)
-                        );
-                      }
+                      const dateSelected = newDate.getTime() === selectedDate?.getTime();
+                      const isDisabled = (minDate && compareDate(minDate, newDate)) || (maxDate && compareDate(newDate, maxDate));
 
                       return (
-                        <div className="cc12DateBlock">&nbsp;</div>
+                        <div className="cc12DateBlock"
+                          key={`${newDate.getTime()}${index}`}
+                        >
+                          <span
+                            className={
+                              cn('cc12Date valign-wrapper cur-po circle bodyRegular14', {
+                                'cc12DateCurrent contentInversePrimary': this.isDateSelected(date),
+                                'cc12DateSelected contentInversePrimary': dateSelected,
+                                'cc12DateNotSelected': !dateSelected && !isDisabled,
+                                'cc12DisableDate': isDisabled
+                              })
+                            }
+                            onClick={
+                              () => {
+                                if (!isDisabled) this.onDateClick(date);
+                              }
+                            }
+                          >
+                            {date}
+                          </span>
+                        </div>
                       );
-                    })
-                  }
-                </div>
-              );
-            })
-          }
-        </div>
+                    }
+
+                    return (
+                      <div className="cc12DateBlock"
+                        key={index}
+                      >&nbsp;</div>
+                    );
+                  })
+                }
+              </div>
+            );
+          })
+        }
       </div>
     );
   }
@@ -215,46 +248,27 @@ class DateCalendar extends React.PureComponent<Props, State> {
 
 
   onDateClick = (date: number) => {
-    const { minDate, maxDate, onDateChange } = this.props;
+    const { onDateChange } = this.props;
     const { dateToShow } = this.state;
     const newDate = new Date(dateToShow);
 
     newDate.setDate(date);
 
-    if (minDate && (this.compareDate(minDate, newDate))) {
-      return;
-    }
-
-    if (maxDate && (this.compareDate(newDate, maxDate))) {
-      return;
-    }
-
     onDateChange(newDate);
-  }
 
-  /* check date1 is greater than date2 */
-  compareDate = (date1: Date, date2: Date) => {
-    const d1 = new Date(date1.getFullYear(), date1.getMonth(), date1.getDate(), 0, 0, 0);
-    const d2 = new Date(date2.getFullYear(), date2.getMonth(), date2.getDate(), 0, 0, 0);
-
-    return d1.getTime() > d2.getTime();
+    this.setState({
+      dateToShow: newDate,
+      selectedDate: newDate
+    });
   }
 
 }
 
 
-type Props = {
-  currentDate: Date;
-  onDateChange: (date:Date)=>void;
-  highlightCurrentDate: boolean;
-  minDate: Date | null;
-  maxDate: Date | null;
-};
-
-
 type State = {
   dateToShow: Date;
   dates: (number | null)[][];
+  selectedDate: Date | null;
 }
 
 

--- a/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx
@@ -81,7 +81,7 @@ class DateCalendar extends React.PureComponent<Props, State> {
     };
 
     return (
-      <div className="valign-wrapper cc12YearBox">
+      <div className="valign-wrapper vspace-between">
         <div className="valign-wrapper cur-po">
           <KeyboardDoubleArrowLeft
             fontSize={21}
@@ -118,7 +118,7 @@ class DateCalendar extends React.PureComponent<Props, State> {
 
   getMonthUI = () => {
     return (
-      <div className='cc12WeekNameBox valign-wrapper contentSecondary bodyRegular14'>
+      <div className='cc12WeekNameBox valign-wrapper vspace-between contentSecondary bodyRegular14'>
         {
           WEEK_DAYS.map((day) => (
             <span className="cc12WeekName"
@@ -170,7 +170,7 @@ class DateCalendar extends React.PureComponent<Props, State> {
                             className={
                               cn('cc12Date valign-wrapper cur-po circle bodyRegular14', {
                                 'cc12DateCurrent contentInversePrimary': this.isDateSelected(date),
-                                'cc12DateSelected contentInversePrimary': dateSelected,
+                                'backgroundPositive contentInversePrimary': dateSelected,
                                 'cc12DateNotSelected': !dateSelected && !isDisabled,
                                 'cc12DisableDate': isDisabled
                               })

--- a/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/index.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/index.tsx
@@ -30,20 +30,23 @@ class MonthCalendar extends React.PureComponent<Props, State> {
     const hasNextYear = !(maxDate && dateToShow.getFullYear() === maxDate.getFullYear());
     const hasPrevYear = !(minDate && dateToShow.getFullYear() === minDate.getFullYear());
 
+    const handlers = {
+      'PREVIOUS_MONTH': () => {
+        if (hasPrevYear) this.goToPreviousYear();
+      },
+      'NEXT_MONTH': () => {
+        if (hasNextYear) this.goToNextYear();
+      }
+    };
+
     return (
       <div className='contentPrimary'>
         <div className='card borderPrimary mn12Box'>
           <div className="valign-wrapper mn12YearRow">
-            <div
-              className="valign-wrapper cur-po"
-            >
+            <div className="valign-wrapper cur-po">
               <KeyboardArrowLeft
                 fontSize={21}
-                onClick={
-                  () => {
-                    if (hasPrevYear) this.goToPreviousYear();
-                  }
-                }
+                onClick={handlers.PREVIOUS_MONTH}
                 className={cn({ 'contentSecondary cur-no': !hasPrevYear })}
               />
             </div>
@@ -51,11 +54,7 @@ class MonthCalendar extends React.PureComponent<Props, State> {
             <div className="valign-wrapper cur-po">
               <KeyboardArrowRight
                 fontSize={21}
-                onClick={
-                  () => {
-                    if (hasNextYear) this.goToNextYear();
-                  }
-                }
+                onClick={handlers.NEXT_MONTH}
                 className={cn({ 'contentSecondary cur-no': !hasNextYear })}
               />
             </div>

--- a/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/index.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/index.tsx
@@ -3,22 +3,32 @@ import cn from 'classnames';
 import { KeyboardArrowLeft, KeyboardArrowRight } from '@groww-tech/icon-store/mi';
 
 import './monthCalendar.css';
+import { compareDate } from '../calendarUtils';
+import { CalendarProps as Props } from '../calendar.types';
 
 const MONTHS = [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ];
 
 class MonthCalendar extends React.PureComponent<Props, State> {
+  static defaultProps = {
+    highlightCurrentDate: true,
+    minDate: null,
+    maxDate: null
+  };
+
 
   state:State = {
-    dateToShow: this.props.currentDate
+    dateToShow: this.props.currentDate,
+    selectedDate: null
   };
 
 
   render() {
-    const { dateToShow } = this.state;
-    const { currentDate } = this.props;
+    const { dateToShow, selectedDate } = this.state;
+    const maxDate = this.props.maxDate ? new Date(this.props.maxDate) : null;
+    const minDate = this.props.minDate ? new Date(this.props.minDate) : null;
 
-    const currentMonthIndex = currentDate.getMonth();
-    const presentDate = new Date();
+    const hasNextYear = !(maxDate && dateToShow.getFullYear() === maxDate.getFullYear());
+    const hasPrevYear = !(minDate && dateToShow.getFullYear() === minDate.getFullYear());
 
     return (
       <div className='contentPrimary'>
@@ -26,38 +36,63 @@ class MonthCalendar extends React.PureComponent<Props, State> {
           <div className="valign-wrapper mn12YearRow">
             <div
               className="valign-wrapper cur-po"
-              onClick={this.handlePrevYearClick}
             >
-              <KeyboardArrowLeft className="mn12YearIcon"/>
+              <KeyboardArrowLeft
+                fontSize={21}
+                onClick={
+                  () => {
+                    if (hasPrevYear) this.goToPreviousYear();
+                  }
+                }
+                className={cn({ 'contentSecondary cur-no': !hasPrevYear })}
+              />
             </div>
-            <div>{dateToShow.getFullYear()}</div>
-            <div
-              className="valign-wrapper  cur-po"
-              onClick={this.handleForwardYearClick}
-            >
-              <KeyboardArrowRight className={cn('mn12YearIcon', { 'contentSecondary cur-no': dateToShow.getFullYear() === new Date().getFullYear() })}/>
+            <span>{dateToShow.getFullYear()}</span>
+            <div className="valign-wrapper cur-po">
+              <KeyboardArrowRight
+                fontSize={21}
+                onClick={
+                  () => {
+                    if (hasNextYear) this.goToNextYear();
+                  }
+                }
+                className={cn({ 'contentSecondary cur-no': !hasNextYear })}
+              />
             </div>
           </div>
           <div className="valign-wrapper mn12MonthBox">
             {
-              MONTHS.map((month, index) => (
-                <div className="mn12Month"
-                  key={`${dateToShow?.getTime()}${index}`}
-                >
-                  <div
-                    className={
-                      cn('mn12MonthText backgroundPrimary valign-wrapper cur-po bodyRegular14', {
-                        'mn12MonthTextSelected contentInversePrimary': ((index === currentMonthIndex) && (currentDate.getFullYear() === dateToShow.getFullYear())),
-                        'mn12MonthBack backgroundPrimary': !((index === currentMonthIndex) && (currentDate.getFullYear() === dateToShow.getFullYear())),
-                        'cc12DisableDate': ((index > presentDate.getMonth()) && (presentDate.getFullYear() === dateToShow.getFullYear()))
-                      })
-                    }
-                    onClick={() => this.onMonthClick(index)}
+              MONTHS.map((month, index) => {
+                const newDate = new Date(dateToShow);
+
+                newDate.setMonth(index);
+                const monthSelected = newDate.getTime() === selectedDate?.getTime();
+                const isDisabled = (minDate && compareDate(minDate, newDate)) || (maxDate && compareDate(newDate, maxDate));
+
+                return (
+                  <div className="mn12Month"
+                    key={`${dateToShow?.getTime()}${index}`}
                   >
-                    {month}
+                    <div
+                      className={
+                        cn('mn12MonthText backgroundPrimary valign-wrapper cur-po bodyRegular14', {
+                          'mn12MonthCurrent contentInversePrimary': this.isMonthSelected(index),
+                          'mn12MonthTextSelected contentInversePrimary': monthSelected,
+                          'mn12MonthBack backgroundPrimary': !monthSelected && !isDisabled,
+                          'cc12DisableDate': isDisabled
+                        })
+                      }
+                      onClick={
+                        () => {
+                          if (!isDisabled) this.onMonthClick(index);
+                        }
+                      }
+                    >
+                      {month}
+                    </div>
                   </div>
-                </div>
-              ))
+                );
+              })
             }
           </div>
         </div>
@@ -66,57 +101,53 @@ class MonthCalendar extends React.PureComponent<Props, State> {
   }
 
 
+  isMonthSelected = (month: number) => {
+    const { currentDate } = this.props;
+    const { dateToShow } = this.state;
+    const currentMonthIndex = currentDate.getMonth();
+
+    return month === currentMonthIndex && currentDate.getFullYear() === dateToShow.getFullYear();
+  }
+
+
   onMonthClick = (index:number) => {
-    const dateToShow = this.state.dateToShow;
-    const newDate = new Date(dateToShow.toString());
-    const presentDate = new Date();
-    const presentMonth = presentDate.getMonth();
+    const { onDateChange } = this.props;
+    const { dateToShow } = this.state;
+    const newDate = new Date(dateToShow);
 
-    if ((index > presentMonth) && (presentDate.getFullYear() === newDate.getFullYear())) {
-      return;
-    }
-
-    newDate.setDate(1);
     newDate.setMonth(index);
 
-    this.props.onDateChange(newDate);
+    onDateChange(newDate);
 
     this.setState({
-      dateToShow: newDate
+      dateToShow: newDate,
+      selectedDate: newDate
     });
   }
 
 
-  handlePrevYearClick = () => {
-    const dateToShow = this.state.dateToShow;
-    const newDate = new Date(dateToShow.toString());
+  goToPreviousYear = () => {
+    const { dateToShow } = this.state;
+    const newDate = new Date(dateToShow);
 
     newDate.setFullYear(dateToShow.getFullYear() - 1);
     this.setState({ dateToShow: newDate });
-  }
+  };
 
 
-  handleForwardYearClick = () => {
-    const dateToShow = this.state.dateToShow;
+  goToNextYear = () => {
+    const { dateToShow } = this.state;
+    const newDate = new Date(dateToShow);
 
-    if (dateToShow.getFullYear() !== new Date().getFullYear()) {
-      const newDate = new Date(dateToShow.toString());
-
-      newDate.setFullYear(dateToShow.getFullYear() + 1);
-      this.setState({ dateToShow: newDate });
-    }
-  }
+    newDate.setFullYear(dateToShow.getFullYear() + 1);
+    this.setState({ dateToShow: newDate });
+  };
 }
-
-
-type Props = {
-  currentDate: Date;
-  onDateChange: (date:Date) => void;
-};
 
 
 type State = {
   dateToShow: Date;
+  selectedDate: Date | null;
 }
 
 export default MonthCalendar;

--- a/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/index.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/index.tsx
@@ -42,7 +42,7 @@ class MonthCalendar extends React.PureComponent<Props, State> {
     return (
       <div className='contentPrimary'>
         <div className='card borderPrimary mn12Box'>
-          <div className="valign-wrapper mn12YearRow">
+          <div className="valign-wrapper vspace-between">
             <div className="valign-wrapper cur-po">
               <KeyboardArrowLeft
                 fontSize={21}
@@ -59,7 +59,7 @@ class MonthCalendar extends React.PureComponent<Props, State> {
               />
             </div>
           </div>
-          <div className="valign-wrapper mn12MonthBox">
+          <div className="valign-wrapper vspace-between mn12MonthBox">
             {
               MONTHS.map((month, index) => {
                 const newDate = new Date(dateToShow);
@@ -81,7 +81,7 @@ class MonthCalendar extends React.PureComponent<Props, State> {
                       className={
                         cn('mn12MonthText backgroundPrimary valign-wrapper cur-po bodyRegular14', {
                           'mn12MonthCurrent contentInversePrimary': this.isMonthSelected(index),
-                          'mn12MonthTextSelected contentInversePrimary': monthSelected,
+                          'backgroundPositive contentInversePrimary': monthSelected,
                           'mn12MonthBack backgroundPrimary': !monthSelected && !isDisabled,
                           'cc12DisableDate': isDisabled
                         })

--- a/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/index.tsx
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/index.tsx
@@ -68,6 +68,11 @@ class MonthCalendar extends React.PureComponent<Props, State> {
                 const monthSelected = newDate.getTime() === selectedDate?.getTime();
                 const isDisabled = (minDate && compareDate(minDate, newDate)) || (maxDate && compareDate(newDate, maxDate));
 
+
+                const onClickHandler = () => {
+                  if (!isDisabled) this.onMonthClick(index);
+                };
+
                 return (
                   <div className="mn12Month"
                     key={`${dateToShow?.getTime()}${index}`}
@@ -81,11 +86,7 @@ class MonthCalendar extends React.PureComponent<Props, State> {
                           'cc12DisableDate': isDisabled
                         })
                       }
-                      onClick={
-                        () => {
-                          if (!isDisabled) this.onMonthClick(index);
-                        }
-                      }
+                      onClick={onClickHandler}
                     >
                       {month}
                     </div>

--- a/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/monthCalendar.css
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/monthCalendar.css
@@ -20,8 +20,13 @@
   margin: 3px auto;
 }
 
+/* NOTE: Here below order matters as active, hover state color override */
 .mn12MonthBack:hover {
   background-color: var(--overlay30);
+}
+
+.mn12MonthCurrent {
+  background-color: var(--green300);
 }
 
 .mn12MonthTextSelected {
@@ -36,4 +41,9 @@
 
 .mn12YearIcon {
   font-size: 22px !important;
+}
+
+.cc12DisableDate {
+  opacity: 0.2;
+  cursor: default;
 }

--- a/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/monthCalendar.css
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/MonthCalendar/monthCalendar.css
@@ -3,10 +3,6 @@
   width: 220px;
 }
 
-.mn12YearRow {
-  justify-content: space-between;
-}
-
 .mn12Month {
   text-align: center;
   min-width: 33%;
@@ -29,13 +25,8 @@
   background-color: var(--green300);
 }
 
-.mn12MonthTextSelected {
-  background-color: var(--green500);
-}
-
 .mn12MonthBox {
   flex-wrap: wrap;
-  justify-content: space-between;
   margin-top: 12px;
 }
 

--- a/packages/ui-toolkit/src/components/molecules/Calendar/calendar.types.ts
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/calendar.types.ts
@@ -1,0 +1,7 @@
+export type CalendarProps = {
+  currentDate: Date;
+  onDateChange: (date:Date)=>void;
+  highlightCurrentDate?: boolean;
+  minDate?: Date | null;
+  maxDate?: Date | null;
+};

--- a/packages/ui-toolkit/src/components/molecules/Calendar/calendarUtils.ts
+++ b/packages/ui-toolkit/src/components/molecules/Calendar/calendarUtils.ts
@@ -47,3 +47,15 @@ export function getMonthAbbrByIndex(monthNumber: number): string {
 
   return monthNames[ monthNumber - 1 ];
 }
+
+
+  /* check date1 is greater than date2 */
+export function compareDate(date1: Date, date2: Date) {
+    // This conversion is required because there is no validation below and .get methods only exists on Date instance unix timestamp will fail
+  date1 = new Date(date1);
+  date2 = new Date(date2);
+  const d1 = new Date(date1.getFullYear(), date1.getMonth(), date1.getDate(), 0, 0, 0);
+  const d2 = new Date(date2.getFullYear(), date2.getMonth(), date2.getDate(), 0, 0, 0);
+
+  return d1.getTime() > d2.getTime();
+}

--- a/packages/ui-toolkit/stories/Calander.stories.tsx
+++ b/packages/ui-toolkit/stories/Calander.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Story } from '@storybook/react';
 
 import { Calendar } from '../src/components/molecules';
-import { Props as CalendarProps, CALENDAR_TYPE } from '../src/components/molecules/Calendar/Calendar';
+import { Props, CALENDAR_TYPE } from '../src/components/molecules/Calendar/Calendar';
 
 export default {
   title: 'Calendar',
@@ -11,7 +11,7 @@ export default {
 };
 
 
-const Template: Story<CalendarProps> = (args) => <Calendar {...args} />;
+const Template: Story<Props> = (args) => <Calendar {...args} />;
 
 
 export const Month = Template.bind({});


### PR DESCRIPTION
## What does this PR do?
1. Added date `active`, `disabled` and `hover` states.2
2. Bounded calendar to `min` and `max` values
3. Removed un-necessary elements and redundant code.
4. Fixed `disabled` state in case of hover
5. Added `onMonthClick | onDateClick`validation
6. Extended props from `MonthCalendar` to `DateCalendar`
7. Added `highlightCurrentDate` prop to show the current date
8. Navigation bar has proper `disabled` state greyed-out in both calendar
9. Changed type prop from `string` to `DATE | MONTH` with fallback to `DATE`
10. Added missing `key` prop in several places to fix un-necessary re-renders.

These fixes were made specifically to address issues with calendar component across `web_apps` like 

1. Active states are not visible or shown, In second SS even though the above range selector shows the current date but that isn't present everywhere.

<img width="438" alt="image" src="https://github.com/Groww/webster/assets/144115086/22d00bdd-0852-4ff6-b4e5-1cda392ee0a8">

<img width="442" alt="image" src="https://github.com/Groww/webster/assets/144115086/440973c9-4956-4c0b-9e46-313012ebad6c">


2. We are able to navigate across the `max | min` date value and shows pointer even on `disabled` state

<img width="435" alt="image" src="https://github.com/Groww/webster/assets/144115086/60bf1283-9518-423f-a2a9-cb77c1f2d7df">

After:

<img width="376" alt="image" src="https://github.com/Groww/webster/assets/144115086/c6a86b4b-5509-427c-af97-972eb961f2d3">

<img width="373" alt="image" src="https://github.com/Groww/webster/assets/144115086/384ef628-c3f1-4924-ae23-86be7376cd58">

<img width="316" alt="image" src="https://github.com/Groww/webster/assets/144115086/82de96ff-b60a-43dc-a76d-72bed9c0a66e">

<img width="523" alt="image" src="https://github.com/Groww/webster/assets/144115086/32fdf058-2e39-442d-aa80-48b06f47a1f4">

Notes:
1. There is no validation when `max` < `min`, Could have thrown an error if `__DEV__` ?
2. Storybook has an issue to validate types properly in controls, refer 4th image in _After_
3. Props for both `MonthCalendar` and `DateCalendar` are now same, however there is no breaking change as props have been extended to additional functionality.
4. `highlightCurrentDate` prop is `true` by default and will highlight the current value, Could be false?
5. Have moved `utils` outside as `compareDate` function was needed in both
6. Earlier `active` state was conditionally improperly https://github.com/Groww/webster/blob/37221681d7bb7e9552a5e5d52d27137868caa29a/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx#L146 this will never work until a re-render is triggered, currently `onDateClick` doesn't update any state so no re-render will trigger and `active` states won't be marked
https://github.com/Groww/webster/blob/37221681d7bb7e9552a5e5d52d27137868caa29a/packages/ui-toolkit/src/components/molecules/Calendar/DateCalendar/index.tsx#L217-L233 
To solve this `selectedDate: Date | null;` was added in React State which is used in calendar dates and will trigger a re-render to mark the new selection date.
7. An assumption was made for `highlightCurrentDate` an already existing color `--green300` has been set and for selected date `--green500`

## What packages have been affected by this PR?
- ui-toolkit

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_


- [x] Bugfix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?
- ui-toolkit -> `0.4.6`

## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [ ] Changes need to be immediately published on npm. 
