### PR TITLE
(fix): ui-toolkit - Select component added readOnly prop

### DIFF
--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/ui-toolkit",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A lightning nature UI",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ui-toolkit/src/components/atoms/Select/Select.tsx
+++ b/packages/ui-toolkit/src/components/atoms/Select/Select.tsx
@@ -58,7 +58,8 @@ class Select extends React.PureComponent<Props> {
       optionsParentClass,
       activeOptionBoxClass,
       activeIndex,
-      dataTestId
+      dataTestId,
+      readonly
     } = this.props;
 
     let selectedOption = null;
@@ -85,6 +86,7 @@ class Select extends React.PureComponent<Props> {
                 <KeyboardArrowDown size={22}/>
 
                 <input
+                  readOnly={readonly}
                   value={selectedOption?.value}
                   onKeyUp={this.onKeyUp}
                   onKeyDown={this.onKeyDown}
@@ -195,7 +197,8 @@ Select.defaultProps = {
   optionsParentClass: '',
   activeOptionBoxClass: '',
   onChange: () => {},
-  dataTestId: ''
+  dataTestId: '',
+  readonly: false
 } as DefaultProps;
 
 
@@ -219,6 +222,8 @@ type DefaultProps = {
   activeOptionBoxClass: string;
   onChange:(e:React.ChangeEvent<HTMLInputElement>)=> void;
   dataTestId: string;
+  /* readonly is useful for phone devices where we are showing data from our own like dropdown */
+  readonly: boolean;
 }
 
 export type Props = RequiredProps & DefaultProps;


### PR DESCRIPTION
## What does this PR do?
There are many cases when we just need to display data to user and take input from existing data. Here we require `readOnly` when the data is being set programmatically. If not handled then it will display a keyboard and text input selection to user.

## What packages have been affected by this PR?
- ui-toolkit

## Types of changes

What types of changes does your code introduce to this project?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?
- ui-toolkit -> `0.4.7`

## Checklist before merging

_Put an `x` in the boxes that apply_

- [x] These changes have been thoroughly tested.

- [ ] Changes need to be immediately published on npm. 
