### PR TITLE
fix(ui-toolkit): RadioButtonGroup Props Handling

### DIFF
--- a/packages/ui-toolkit/package.json
+++ b/packages/ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groww-tech/ui-toolkit",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "A lightning nature UI",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ui-toolkit/src/components/atoms/RadioButton/RadioButton.tsx
+++ b/packages/ui-toolkit/src/components/atoms/RadioButton/RadioButton.tsx
@@ -16,8 +16,7 @@ const RadioButton = (props: Props) => {
     onSelect,
     radioDirection,
     dataTestId,
-    isDisabled,
-    labelClassName
+    isDisabled
   } = props;
 
   const iconColor = isDisabled ? 'var(--gray400)' : 'var(--green500)';
@@ -33,7 +32,7 @@ const RadioButton = (props: Props) => {
     bodyBase: size === SIZES.BASE,
     bodyLarge: size === SIZES.LARGE,
     bodyXLarge: size === SIZES.XLARGE
-  }, labelClassName);
+  });
 
 
   const radioButtonClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
@@ -93,7 +92,6 @@ type RequiredProps = {
   label: React.ReactNode;
   isSelected: boolean;
   onSelect: () => void;
-  labelClassName?: string;
 }
 
 

--- a/packages/ui-toolkit/src/components/atoms/RadioButton/RadioButton.tsx
+++ b/packages/ui-toolkit/src/components/atoms/RadioButton/RadioButton.tsx
@@ -16,7 +16,8 @@ const RadioButton = (props: Props) => {
     onSelect,
     radioDirection,
     dataTestId,
-    isDisabled
+    isDisabled,
+    labelClassName
   } = props;
 
   const iconColor = isDisabled ? 'var(--gray400)' : 'var(--green500)';
@@ -32,7 +33,7 @@ const RadioButton = (props: Props) => {
     bodyBase: size === SIZES.BASE,
     bodyLarge: size === SIZES.LARGE,
     bodyXLarge: size === SIZES.XLARGE
-  });
+  }, labelClassName);
 
 
   const radioButtonClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
@@ -92,6 +93,7 @@ type RequiredProps = {
   label: React.ReactNode;
   isSelected: boolean;
   onSelect: () => void;
+  labelClassName?: string;
 }
 
 

--- a/packages/ui-toolkit/src/components/molecules/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/ui-toolkit/src/components/molecules/RadioButtonGroup/RadioButtonGroup.tsx
@@ -23,27 +23,15 @@ const RadioButtonGroup = (props: Props) => {
     >
       {
         radioButtons.map((item: RadioButtonType, index: number) => {
-          const {
-            value,
-            parentClassName,
-            label,
-            size,
-            labelClassName,
-            radioDirection
-          } = item;
 
           return (
-            <div
-              key={`${value}${index}`}
-              className={parentClassName}
-            >
+            <div key={`${item.value}${index}`}>
               <RadioButton
                 isSelected={selected === item.value}
                 onSelect={() => onSelect(item.value)}
-                label={label}
-                size={size}
-                labelClassName={labelClassName}
-                radioDirection={radioDirection}
+                label={item.label}
+                size={item.size}
+                radioDirection={item.radioDirection}
                 dataTestId= {dataTestId ? index + '-' + dataTestId + '-radio-button' : ''}
               />
             </div>

--- a/packages/ui-toolkit/src/components/molecules/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/ui-toolkit/src/components/molecules/RadioButtonGroup/RadioButtonGroup.tsx
@@ -8,24 +8,42 @@ import './radioButtonGroup.css';
 
 const RadioButtonGroup = (props: Props) => {
 
-  const { radioButtons, containerClassName,
-    dataTestId, onSelect, selected, ...restProps } = props;
+  const {
+    radioButtons,
+    containerClassName,
+    dataTestId,
+    onSelect,
+    selected
+  } = props;
 
   return (
-    <div id="container"
+    <div
+      id="container"
       className={containerClassName}
     >
       {
         radioButtons.map((item: RadioButtonType, index: number) => {
+          const {
+            value,
+            parentClassName,
+            label,
+            size,
+            labelClassName,
+            radioDirection
+          } = item;
+
           return (
-            <div key={`${item.value}${index}`}
-              {...restProps}
+            <div
+              key={`${value}${index}`}
+              className={parentClassName}
             >
               <RadioButton
                 isSelected={selected === item.value}
                 onSelect={() => onSelect(item.value)}
-                label={item.label}
-                radioDirection={item.radioDirection}
+                label={label}
+                size={size}
+                labelClassName={labelClassName}
+                radioDirection={radioDirection}
                 dataTestId= {dataTestId ? index + '-' + dataTestId + '-radio-button' : ''}
               />
             </div>

--- a/packages/ui-toolkit/stories/RadioButtonGroup.stories.tsx
+++ b/packages/ui-toolkit/stories/RadioButtonGroup.stories.tsx
@@ -27,7 +27,8 @@ const Template: Story<RadioButtonGroupProps> = (args) => {
 
   return (
     <div className="valign-wrapper">
-      <RadioButtonGroup {...args}
+      <RadioButtonGroup
+        {...args}
         selected={value}
         onSelect={onSelect}
       />

--- a/packages/ui-toolkit/stories/RadioButtonGroup.stories.tsx
+++ b/packages/ui-toolkit/stories/RadioButtonGroup.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Story } from "@storybook/react";
+import { Story } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import { Props as RadioButtonGroupProps } from '../src/components/molecules/RadioButtonGroup/RadioButtonGroup';
@@ -7,49 +7,54 @@ import { RadioButtonGroup } from '../src/components/molecules';
 
 export default {
   title: 'RadioButtonGroup',
-  component: RadioButtonGroup,
+  component: RadioButtonGroup
 };
 
+
 const Template: Story<RadioButtonGroupProps> = (args) => {
-  const [value, setValue] = useState("");
+  const [ value, setValue ] = useState('');
+
 
   const onSelect = (newValue) => {
     if (newValue === value) {
-      setValue("");
+      setValue('');
 
     } else {
       setValue(newValue);
 
     }
-  }
+  };
 
   return (
     <div className="valign-wrapper">
-      <RadioButtonGroup {...args} selected={value} onSelect={onSelect} />
+      <RadioButtonGroup {...args}
+        selected={value}
+        onSelect={onSelect}
+      />
     </div>
-  )
+  );
 };
 
 export const Default = Template.bind({});
 
 const genderArray = [
-  { label: "Male", value: "MALE" },
-  { label: "Female", value: 'FEMALE', parentClassName: "bas11RadioParent" },
-  { label: "Other", value: "NA", parentClassName: "bas11RadioParent" }
+  { label: 'Male', value: 'MALE' },
+  { label: 'Female', value: 'FEMALE', parentClassName: 'bas11RadioParent' },
+  { label: 'Other', value: 'NA', parentClassName: 'bas11RadioParent' }
 ];
 
 Default.args = {
-  containerClassName: "",
-  radioButtons: genderArray,
+  containerClassName: '',
+  radioButtons: genderArray
 };
 
 export const Custom = Template.bind({});
 
 const switchArray = [
-  { label: "On", value: "ON", radioDirection: 'Right' },
-  { label: "Off", value: 'OFF', parentClassName: "bas11RadioParent" }
+  { label: 'On', value: 'ON', radioDirection: 'Right' },
+  { label: 'Off', value: 'OFF', parentClassName: 'bas11RadioParent' }
 ];
 
 Custom.args = {
-  radioButtons: switchArray,
-}
+  radioButtons: switchArray
+};

--- a/packages/ui-toolkit/stories/RadioButtonGroup.stories.tsx
+++ b/packages/ui-toolkit/stories/RadioButtonGroup.stories.tsx
@@ -40,8 +40,8 @@ export const Default = Template.bind({});
 
 const genderArray = [
   { label: 'Male', value: 'MALE', size: 'Base', radioDirection: 'Left' },
-  { label: 'Female', value: 'FEMALE', parentClassName: 'bas11RadioParent' },
-  { label: 'Other', value: 'NA', labelClassName: 'bas11RadioLabelParent' }
+  { label: 'Female', value: 'FEMALE' },
+  { label: 'Other', value: 'NA' }
 ];
 
 Default.args = {
@@ -53,7 +53,7 @@ export const Custom = Template.bind({});
 
 const switchArray = [
   { label: 'On', value: 'ON', radioDirection: 'Right' },
-  { label: 'Off', value: 'OFF', parentClassName: 'bas11RadioParent' }
+  { label: 'Off', value: 'OFF' }
 ];
 
 Custom.args = {

--- a/packages/ui-toolkit/stories/RadioButtonGroup.stories.tsx
+++ b/packages/ui-toolkit/stories/RadioButtonGroup.stories.tsx
@@ -38,9 +38,9 @@ const Template: Story<RadioButtonGroupProps> = (args) => {
 export const Default = Template.bind({});
 
 const genderArray = [
-  { label: 'Male', value: 'MALE' },
+  { label: 'Male', value: 'MALE', size: 'Base', radioDirection: 'Left' },
   { label: 'Female', value: 'FEMALE', parentClassName: 'bas11RadioParent' },
-  { label: 'Other', value: 'NA', parentClassName: 'bas11RadioParent' }
+  { label: 'Other', value: 'NA', labelClassName: 'bas11RadioLabelParent' }
 ];
 
 Default.args = {


### PR DESCRIPTION
## What does this PR do?

- Add support for `parentClassName`, `size`, `labelClassName`
- Removed unused `restProps` 
- Update RadioButton component to accept `labelClassName` prop
- Adjust stories to demonstrate the use of additional props


## What packages have been affected by this PR?
- `ui-toolkit`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Package version increase in any of the packages?



## Checklist before merging

- [x] These changes have been thoroughly tested.
- [ ] Changes need to be immediately published on npm. 
